### PR TITLE
 flake: init nix! 

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ options.ron
 *.cap
 
 **/items/**/*.blend
+
+.direnv
+result

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,92 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "naersk": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      },
+      "locked": {
+        "lastModified": 1713520724,
+        "narHash": "sha256-CO8MmVDmqZX2FovL75pu5BvwhW+Vugc7Q6ze7Hj8heI=",
+        "owner": "nix-community",
+        "repo": "naersk",
+        "rev": "c5037590290c6c7dae2e42e7da1e247e54ed2d49",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "naersk",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 0,
+        "narHash": "sha256-uSO9tieOIet9IFghVsInF2G2cCS3xHWGBD1Jto/bsOQ=",
+        "path": "/nix/store/xg7mvghndqbn9y68zh2gb7m8kk9my449-source",
+        "type": "path"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1713537308,
+        "narHash": "sha256-XtTSSIB2DA6tOv+l0FhvfDMiyCmhoRbNB+0SeInZkbk=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "5c24cf2f0a12ad855f444c30b2421d044120c66f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "naersk": "naersk",
+        "nixpkgs": "nixpkgs_2"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,64 @@
+{
+  inputs = {
+    flake-utils.url = "github:numtide/flake-utils";
+    naersk.url = "github:nix-community/naersk";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+  };
+
+  outputs = { self, flake-utils, naersk, nixpkgs }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = (import nixpkgs) { inherit system; };
+        inherit (pkgs) lib;
+
+        naersk' = pkgs.callPackage naersk { };
+
+        buildInputs = with pkgs; [
+          alsa-lib
+          libxkbcommon
+          vulkan-loader
+          wayland
+          xorg.libX11
+          libGL
+          # a few of these are probably extra
+          xorg.libXcursor
+          xorg.libXi
+          xorg.libXrandr
+        ];
+
+        binInputs = with pkgs; [
+          gnome.zenity
+        ];
+
+      in rec {
+        # For `nix build` & `nix run`:
+        defaultPackage = naersk'.buildPackage {
+          src = ./.;
+          nativeBuildInputs = with pkgs; [ pkg-config blender makeBinaryWrapper ];
+          inherit buildInputs;
+
+          cargoBuildOptions = prev: prev ++ [ "--features build-binary" ];
+
+          postInstall = ''
+            wrapProgram "$out/bin/automancy" \
+              --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath buildInputs } \
+              --prefix PATH : "${lib.makeBinPath binInputs}"
+
+            # TODO? --suffix XDG_DATA_DIRS : "$${cosmic-icons}/share" \
+          '';
+        };
+
+        # For `nix develop`:
+        devShell = pkgs.mkShell {
+          nativeBuildInputs = with pkgs; [
+            rustc
+            cargo
+            rust-analyzer
+            pkg-config
+            blender
+          ] ++ binInputs;
+          inherit buildInputs;
+          LD_LIBRARY_PATH = lib.makeLibraryPath buildInputs;
+        };
+      });
+}

--- a/install.sh
+++ b/install.sh
@@ -12,3 +12,6 @@ if ! [ -f "./automancy" ] || ! [ -d "./resources" ]; then
   echo $'\e[1;31mCould not find all of the installation files! Please try redownloading.\e[0m'
   exit 1
 fi
+
+echo "<script unimplemented>"
+exit 1


### PR DESCRIPTION
Add a Nix flake. This allows for reproducible builds and easy usage on
NixOS :3

Currently, automancy does not look for its `resources` intelligently,
and "loses" them if you aren't in a directory with `./resources`.


also indicate `install.sh` is wip

also setup direnv cuz nice